### PR TITLE
docs(global): Add steps for global installs

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}
+

--- a/README.md
+++ b/README.md
@@ -2,6 +2,34 @@
 
 This is our company commitizen configuration. We uses cz-bespoke to generate a commitizen adapter.
 
+
+### Global Installation
+It is recommended to configure commitizen globally on your computer so you can take advantage in every git repository.
+
+To install the packages and configure commitizen, run the following:
+```bash
+# Install commitizen globally
+npm i -g commitizen
+
+# Install commitizen adapter globally
+npm i -g @concierge-auctions/commitizen-config
+
+echo "{ \"path\": \"@concierge-auctions/commitizen-config\" }" > ~/.czrc
+
+```
+
+Now you can commit with `git cz` instead of `git commit`!
+
+
+#### Troubleshooting
+Because the adapter is in a scoped npm package, an `.npmrc` is likely to be required in the directory you install from. An `.npmrc` file has been checked in, but this is worth noting.
+
+Another source of problems is a turf war between npm and yarn. I would recommend installing both dependencies using one of the, and uninstalling both dependencies from the other (if applicable).
+
+
+
+
+### Repo Installation
 To add commitizen to a repo, do the following:
 
 1. Install commitizen globally. (This isn't necessary, but makes using the cli tool easier.)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concierge-auctions/commitizen-config",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Company commitizen configuration",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Global installation of the package has the potential to be
much more time efficient than maintaining an up-to-date
commitizen configuration in each of our many repos.

This adds instructions to the README for global setup.

Bumped version so npm docs are up to date.